### PR TITLE
Remove usage of deprecated with_defaults

### DIFF
--- a/tests/testthat/test-lint_check.R
+++ b/tests/testthat/test-lint_check.R
@@ -1,10 +1,9 @@
 test_that("Linting package", {
 
-  config <- lintr::with_defaults(
-    default = lintr:: default_linters,
+  config <- lintr::modify_defaults(
+    lintr::default_linters,
     line_length_linter = lintr::line_length_linter(120),
     object_usage_linter = NULL,
-    camel_case_linter = NULL,
     object_name_linter = NULL
   )
 


### PR DESCRIPTION
`with_defaults()` has been deprecated since {lintr} 3.0.0, 3 years ago; a pending release will change calling `with_defaults()` from warning to error, breaking this test.